### PR TITLE
Added exemplary task manifest with specified interface

### DIFF
--- a/examples/tasks/iface_all-file.json
+++ b/examples/tasks/iface_all-file.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/iface/*": {}
+      },
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_interface"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/tasks/iface_eno1-file_influxdb.json
+++ b/examples/tasks/iface_eno1-file_influxdb.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/iface/eno1/*": {}
+      },
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_interface_eno1"
+          }
+        },
+        {
+          "plugin_name": "influxdb",
+          "config": {
+            "host": "127.0.0.1",
+            "port": 8086,
+            "database": "snap",
+            "user": "admin",
+            "password": "admin"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/tasks/iface_enp2s0-file_influxdb.json
+++ b/examples/tasks/iface_enp2s0-file_influxdb.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "1s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/procfs/iface/enp2s0/packets_recv": {},
+        "/intel/procfs/iface/enp2s0/packets_sent": {},
+        "/intel/procfs/iface/enp2s0/bytes_recv": {},
+        "/intel/procfs/iface/enp2s0/bytes_sent": {}
+      },
+      "publish": [
+        {
+          "plugin_name": "file",
+          "config": {
+            "file": "/tmp/published_interface_enp2s0"
+          }
+        },
+        {
+          "plugin_name": "influxdb",
+          "config": {
+            "host": "127.0.0.1",
+            "port": 8086,
+            "database": "snap",
+            "user": "admin",
+            "password": "admin"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/intelsdi-x/snap-plugin-collector-interface/issues/13

## Summary of changes:
- added exemplary task manifest to show how to request metrics per-interface 

## How to verify it:
- run exemplary task manifest with specified interface

### Example:
1. load snap-plugin-collector-interface:
```
snaptel plugin load snaptel plugin load ./build/linux/x86_64/snap-plugin-collector-interface
```

2. create task manifest with a specified dynamic element (interface), see examples/tasks/:
```
{
  "version": 1,
  "schedule": {
    "type": "simple",
    "interval": "1s"
  },
  "workflow": {
    "collect": {
      "metrics": {
        "/intel/procfs/iface/eno1/*": {}
      },
      "publish": [
        {
          "plugin_name": "file",
          "config": {
            "file": "/tmp/published_interface_eno1"
          }
        },
        {
          "plugin_name": "influxdb",
          "config": {
            "host": "127.0.0.1",
            "port": 8086,
            "database": "snap",
            "user": "admin",
            "password": "admin"
          }
        }
      ]
    }
  }
}
```

3. load declared publishers:  snap-plugin-publisher-influxdb and snap-plugin-publisher-file:
```
snaptel plugin load snaptel plugin load <path-to-snap-plugin-publisher-influxdb>
snaptel plugin load snaptel plugin load <path-to-snap-plugin-publisher-file>
```

4. create a task:
```
$ snaptel task create -t  examples/tasks/iface_eno1-file_influxdb.json

Using task manifest to create task
Task created
ID: 72166b3e-4236-46ef-89f1-a9088441f113
Name: Task-72166b3e-4236-46ef-89f1-a9088441f113
State: Running
```

5. watch collected metrics:
(notice, that they comes only from specified interface `eno1`)
```
$ snaptel task watch  72166b3e-4236-46ef-89f1-a9088441f113

Watching Task (72166b3e-4236-46ef-89f1-a9088441f113):
NAMESPACE                                        DATA                    TIMESTAMP
/intel/procfs/iface/eno1/bytes_recv              1.8418728438e+10        2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/bytes_sent              2.8270863484e+10        2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/compressed_recv         0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/compressed_sent         0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/drop_recv               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/drop_sent               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/errs_recv               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/errs_sent               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/fifo_recv               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/fifo_sent               0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/frame_recv              0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/frame_sent              0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/multicast_recv          7.156362e+06            2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/multicast_sent          0                       2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/packets_recv            3.5404287e+07           2016-12-01 14:22:55.672502653 +0100 CET
/intel/procfs/iface/eno1/packets_sent            3.379646e+07            2016-12-01 14:22:55.672502653 +0100 CET
```

