### PR TITLE
Added HW Address and MTU to the collected networks metrics

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -21,3 +21,5 @@ Namespace | Description (optional)
 /intel/procfs/iface/\<interface_name\>/multicast_sent | The number of multicast frames transmitted by the device driver
 /intel/procfs/iface/\<interface_name\>/packets_recv | The total number of packets of data received by the interface
 /intel/procfs/iface/\<interface_name\>/packets_sent | The total number of packets of data transmitted by the interface
+
+All collected samples contains information about the hardware address (tag -> hardware_address) and the MTU (tag -> mtu).


### PR DESCRIPTION
- Added HW Address and MTU to the collected networks metrics
- interface used as a dynamic metric key renamed to the interface_name to unify this key, tag for all network collectors. like psutil, interface.
